### PR TITLE
Rename store.js to prevent conflict with another module 'store.js'

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -15,7 +15,7 @@ import { Provider } from 'react-redux';
 import { applyRouterMiddleware, Router, browserHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 import FontFaceObserver from 'fontfaceobserver';
-import { useScroll } from 'react-router-scroll';
+import useScroll from 'react-router-scroll/lib/useScroll';
 import 'sanitize.css/sanitize.css';
 
 // Import root app

--- a/docs/js/routing.md
+++ b/docs/js/routing.md
@@ -195,9 +195,9 @@ export function* getXhrPodcast(slug) {
 }
 ```
 
-Wait (`take`) for the LOAD_POST constant, which contains the slug payload from the `getPost()` function in actions.js. 
+Wait (`take`) for the LOAD_POST constant, which contains the slug payload from the `getPost()` function in actions.js.
 
 When the action is fired then dispatch the `getXhrPodcast()` function to get the response from your api. On success dispatch the `postLoaded()` action (`yield put`) which sends back the response and can be added into the reducer state.
 
 
-You can read more on [`react-router`'s documentation](https://github.com/reactjs/react-router/blob/master/docs/API.md#props-3).
+You can read more on [`react-router`'s documentation](https://reacttraining.com/react-router/web/api).

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
         2,
         "as-needed"
       ],
+      "class-methods-use-this": 0,
       "comma-dangle": [
         2,
         "always-multiline"
@@ -120,6 +121,7 @@
       "import/no-extraneous-dependencies": 0,
       "import/no-named-as-default": 0,
       "import/no-unresolved": 2,
+      "import/no-webpack-loader-syntax": 0,
       "import/prefer-default-export": 0,
       "indent": [
         2,
@@ -141,7 +143,6 @@
       "no-console": 1,
       "no-use-before-define": 0,
       "prefer-template": 2,
-      "class-methods-use-this": 0,
       "react/forbid-prop-types": 0,
       "react/jsx-first-prop-new-line": [
         2,
@@ -149,13 +150,12 @@
       ],
       "react/jsx-filename-extension": 0,
       "react/jsx-no-target-blank": 0,
+      "react/require-default-props": 0,
       "react/require-extension": 0,
       "react/self-closing-comp": 0,
       "redux-saga/no-yield-in-race": 2,
       "redux-saga/yield-effects": 2,
-      "require-yield": 0,
-      "import/no-webpack-loader-syntax": 0,
-      "react/require-default-props": 0
+      "require-yield": 0
     },
     "settings": {
       "import/resolver": {


### PR DESCRIPTION
There is another popular npm package called [store.js](https://github.com/marcuswestin/store.js/). If one install the npm package, then it has conflict with the existing file store.js in the app folder due to webpack alias. 